### PR TITLE
Bug 748563 - send HTML mail, add bug links

### DIFF
--- a/kittenherder.py
+++ b/kittenherder.py
@@ -37,6 +37,7 @@ import datetime
 import smtplib
 import email.utils
 
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from multiprocessing import Process, Queue, get_logger
 from Queue import Empty
@@ -125,6 +126,106 @@ def getHistory(kitten):
 #                     'tacfile': '', 'pdu': False, 'fqdn': 'bm-xserve20.build.sjc1.mozilla.com.', 'reboot': False, 'reachable': False, 'lastseen': None,
 #                     'buildbot': '', 'master': ''}
 
+def HTMLEmailHeader(title):
+    header =  """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>"""
+    header += title
+    header += """</title>
+<link rel="stylesheet" href="http://build.mozilla.org/builds/kitten_mail.css" />
+</head>
+
+<body>
+"""
+    header += '<h1>%s</h1>' % title
+    return header
+
+def HTMLEmailFooter():
+    return """
+<hr/>
+<p class="center"><a href="http://build.mozilla.org/builds/last-job-per-slave.html">last job per slave</a> | <a href="http://slavealloc.build.mozilla.org/ui/">slavealloc</a></p>
+
+</body>
+</html>
+
+"""
+
+def getPlatform(kitten):
+    if 'try-mac64' in kitten or \
+       'talos-r4-snow-' in kitten or \
+       'lion' in kitten or \
+       'centos5-64' in kitten or \
+       'centos6' in kitten or \
+       'linux64' in kitten or \
+       'talos-r3-fed64-' in kitten or \
+       'w64' in kitten or \
+       'w764' in kitten:
+        return 'x86_64'
+    elif 'mw32' in kitten or \
+         'moz2-darwin10' in kitten or \
+         'centos5-32' in kitten or \
+         'linux-ix' in kitten or \
+         'talos-r3-fed-' in kitten or \
+         'talos-r3-leopard' in kitten or \
+         'talos-r3-w7-' in kitten or \
+         'talos-r3-xp-' in kitten:
+        return 'x86'    
+    elif 'tegra' in kitten:
+        return 'ARM'
+    else:
+        return ''
+
+def getOS(kitten):
+    if 'try-mac64' in kitten or \
+       'lion' in kitten or \
+       'moz2-darwin10' in kitten or \
+       'talos-r3-leopard' in kitten or \
+       'talos-r4-snow-' in kitten:
+        return 'Mac%20OS%20X'
+    elif 'centos' in kitten or \
+         'linux' in kitten or \
+         'talos-r3-fed' in kitten:
+        return 'Linux'
+    elif 'w64' in kitten:
+        return 'Windows%20Server%202008'
+    elif 'w7' in kitten:
+        return 'Windows%207'
+    elif 'xp' in kitten:
+        return 'Windows%20XP'
+    elif 'tegra' in kitten:
+        return 'Android'
+    else:
+        return ''
+
+def getTemplateLink(kitten):
+    platform = getPlatform(kitten)
+    os       = getOS(kitten)
+    link = '<a href="https://bugzilla.mozilla.org/enter_bug.cgi?alias=' + kitten + '&assigned_to=nobody%40mozilla.org&bug_severity=normal&bug_status=NEW&component=Release%20Engineering%3A%20Machine%20Management&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&defined_groups=1&flag_type-4=X&flag_type-481=X&flag_type-607=X&flag_type-674=X&flag_type-720=X&flag_type-721=X&flag_type-737=X&flag_type-775=X&flag_type-780=X&form_name=enter_bug&keywords=&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Mac%20OS%20X&priority=--&product=mozilla.org&qa_contact=armenzg%40mozilla.com&rep_platform=' + platform + '&requestee_type-4=&requestee_type-607=&requestee_type-753=&short_desc=' + kitten + '%20problem%20tracking&status_whiteboard=%5Bbuildduty%5D%5Bbuildslave%5D%5Bcapacity%5D&version=other">File new bug</a>'
+    return link
+
+def formatHTMLResults(table_header, kitten_list):
+    results = """
+<table cellpadding="0" cellspacing="0" width="620" class="body">
+<tr>
+"""
+    results += '<th colspan="3">%s</th>\n' % table_header
+    results += '</tr>\n'
+
+    row_class = 'odd'
+    for kitten in kitten_list:        
+        results += '<tr class="%s"><td>%s</td>\n' % (row_class,kitten)
+        results += '<td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=%s">Check Existing Bug</a></td>\n' % kitten
+        results += '<td>' + getTemplateLink(kitten) + '</td>\n'
+        results += '</tr>\n'
+        if row_class == 'odd':
+            row_class = 'even'
+        else:
+            row_class = 'odd'
+    results += '</table>'
+    return results
+
 def sendEmail(data, smtpServer=None):
     if len(data) > 0:
         rebootedOS   = []
@@ -134,6 +235,7 @@ def sendEmail(data, smtpServer=None):
         idle         = []
         neither      = []
         body         = ''
+        html_body    = ''
 
         lastRun = db.lrange('kittenherder:lastrun', 0, -1)
         db.ltrim('kittenherder:lastrun', 0, 0)
@@ -167,35 +269,46 @@ def sendEmail(data, smtpServer=None):
             prevSeen = previouslySeen(rebootedOS, lastRun)
             body += generate(rebootedOS, 'rebooted (SSH)')
             body += prevSeen
+            html_body += formatHTMLResults('rebooted (SSH)', rebootedOS)
 
         if len(rebootedPDU) > 0:
             prevSeen = previouslySeen(rebootedPDU, lastRun)
             body += generate(rebootedPDU, 'rebooted (PDU)')
             body += prevSeen
+            html_body += formatHTMLResults('rebooted (PDU)', rebootedPDU)
 
         if len(rebootedIPMI) > 0:
             prevSeen = previouslySeen(rebootedIPMI, lastRun)
             body += generate(rebootedIPMI, 'rebooted (IPMI)')
             body += prevSeen
+            html_body += formatHTMLResults('rebooted (IPMI)', rebootedIPMI) 
 
         if len(recovered) > 0:
             body += '\r\nrecovery needed\r\n'
             for kitten in recovered:
                 body += '%s\r\n%s' % (kitten, getHistory(kitten))
+            html_body += formatHTMLResults('recovery needed', recovered)
 
         if len(neither) > 0:
             body += '\r\nbear needs to look into these\r\n    %s\r\n' % ', '.join(neither)
 
         if len(body) > 0:
-            addr = 'release@mozilla.com'
-            msg  = MIMEText(body)
+            addr = 'release@mozilla.com'                                     
+            msg = MIMEMultipart('alternative') 
 
             msg.set_unixfrom('briarpatch')
             msg['To']      = email.utils.formataddr(('RelEng',     addr))
             msg['From']    = email.utils.formataddr(('briarpatch', addr))
             msg['Subject'] = '[briar-patch] idle kittens report'
 
-            print body
+            textPart = MIMEText(body, 'plain')                                
+            htmlPart = MIMEText(HTMLEmailHeader('[briar-patch] idle kittens report') + \
+                                html_body + \
+                                HTMLEmailFooter(), 'html')
+
+            msg.attach(textPart)                                              
+            msg.attach(htmlPart)
+
             if smtpServer is not None:
                 server = smtplib.SMTP(smtpServer)
                 server.set_debuglevel(True)

--- a/releng/remote.py
+++ b/releng/remote.py
@@ -625,7 +625,7 @@ class RemoteEnvironment():
 
         elif 'moz2-linux' in hostname or 'linux-ix' in hostname or \
              'try-linux' in hostname or 'linux64-ix-' in hostname or \
-             'bld-centos6' in hostname:
+             'bld-centos' in hostname:
             result = LinuxBuildHost(hostname, self, verbose=verbose)
 
         elif 'try-mac' in hostname or 'xserve' in hostname or \


### PR DESCRIPTION
This is the first part to bug 748563.
- sends multi-part mail, so we don't lose any of the test additions bear has added recently
  *_...while adding an HTML tabular output with links to bugs
  *_ I don't find the historical timestamp useful, at least not until it is used to determine a next step and not displayed itself
- changes parsing on centos slaves so we actually cover centos5 VMs

The platform and OS detection for creating the bug links is ugly. If there's a better way to do those comparisons, please do suggest it.
